### PR TITLE
Fix capitalization of filenames in #include directives

### DIFF
--- a/examples/MagicianCooperation/AIStarter/AIStarter.ino
+++ b/examples/MagicianCooperation/AIStarter/AIStarter.ino
@@ -9,7 +9,7 @@
 ** Latest Version:        V1.0.0
 ** Descriptions:          Ai-Starter Demo
 *********************************************************************************************************/
-#include "AISTARTER.h"
+#include "AIStarter.h"
 #define  Threshold 15             //设置颜色阈值
 #define  IR_NUM    6              //设置红外对管数量
 #define  DBG_EN    0              

--- a/src/Beep.cpp
+++ b/src/Beep.cpp
@@ -1,4 +1,4 @@
-#include "arduino.h"
+#include "Arduino.h"
 #include "Beep.h"
 
 int BeepInit(void)

--- a/src/Beep.h
+++ b/src/Beep.h
@@ -1,7 +1,7 @@
 #ifndef __BEEP_H
 #define __BEEP_H
 
-#include "arduino.h"
+#include "Arduino.h"
 
 #define BEEP 11 //PB5
 

--- a/src/E2PROM.h
+++ b/src/E2PROM.h
@@ -2,7 +2,7 @@
 #define __E2PROM_H
 
 #include <EEPROM.h>
-#include "arduino.h"
+#include "Arduino.h"
 
 typedef enum
 {

--- a/src/HC-SR04.cpp
+++ b/src/HC-SR04.cpp
@@ -1,5 +1,5 @@
-#include "HC-SR04.H"
-#include "arduino.h"
+#include "HC-SR04.h"
+#include "Arduino.h"
 #define SONARDEBUG false
 
 int gSonarTime = 3000;

--- a/src/IRModule.cpp
+++ b/src/IRModule.cpp
@@ -1,5 +1,5 @@
 #include "IRModule.h"
-#include "arduino.h"
+#include "Arduino.h"
 
 int IRInit()
 {

--- a/src/MMC5883L.cpp
+++ b/src/MMC5883L.cpp
@@ -1,5 +1,5 @@
 
-#include "MMC5883L.H"
+#include "MMC5883L.h"
 
 #define YAW_AXIS_IS_X 0
 #define YAW_AXIS_IS_Y 0

--- a/src/MMC5883L.h
+++ b/src/MMC5883L.h
@@ -1,7 +1,7 @@
 #ifndef __MMC5883L_H
 #define __MMC5883L_H
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "SoftI2CMaster.h"
 #include "E2PROM.h"
 

--- a/src/Motor.cpp
+++ b/src/Motor.cpp
@@ -1,4 +1,4 @@
-#include "arduino.h"
+#include "Arduino.h"
 #include "Motor.h"
 
 volatile float gCounterR = 0;

--- a/src/SmartBot.h
+++ b/src/SmartBot.h
@@ -18,11 +18,11 @@
 #ifndef __SMARTBOT_H
 #define __SMARTBOT_H
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "Beep.h"
 #include "HC-SR04.h"
 #include "IRModule.h"
-#include "MMC5883L.H"
+#include "MMC5883L.h"
 #include "Motor.h"
 #include "TCS3200.h"
 #include "TimerOne.h"

--- a/src/TCS3200.cpp
+++ b/src/TCS3200.cpp
@@ -1,5 +1,5 @@
 #include "TCS3200.h"
-#include "arduino.h"
+#include "Arduino.h"
 #include "TimerOne.h"
 #include "stdio.h"
 #include "SoftI2CMaster.h"

--- a/src/TCS3200.h
+++ b/src/TCS3200.h
@@ -1,7 +1,7 @@
 #ifndef __TSC3200_H
 #define __TSC3200_H
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "E2PROM.h"
 #define WBBASIC 200
 


### PR DESCRIPTION
Incorrect capitalization of the filenames caused compilation to fail on filename case-sensitive operating systems like Linux:
```
/home/builder/opt/libraries/latest/aistarter_1_0_1/src/SmartBot.h:21:21: fatal error: arduino.h: No such file or directory
```