### PR TITLE
Change author/maintainer from Arduino to Dobotopensource

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=AIStarter
 version=1.0.1
-author=Arduino
-maintainer=Arduino <info@arduino.cc>
+author= Dobotopensource
+maintainer= Dobotopensource
 sentence= AIStarter programming interface.
 paragraph= AIStarter programming interface.
 category= Device Control


### PR DESCRIPTION
The https://github.com/dobotopensource/AIStarter library is not maintained by the Arduino Team. This PR assigns dobotopensource as the maintainer and author inside the `library.properties` file. 